### PR TITLE
Feature/argo template for local

### DIFF
--- a/argo-workflows-templates/nvm-compute-template-geth-localnet.yaml
+++ b/argo-workflows-templates/nvm-compute-template-geth-localnet.yaml
@@ -120,7 +120,7 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: workdir
-          - name: artifacts
+          - name: minikube-mount
             mountPath: /artifacts
 
     - name: transformation-pod-compute
@@ -203,7 +203,7 @@ spec:
         volumeMounts:
           - mountPath: /data
             name: workdir
-          - name: artifacts
+          - name: minikube-mount
             mountPath: /artifacts
 
   volumeClaimTemplates:
@@ -215,10 +215,10 @@ spec:
         resources:
           requests:
             storage: 2Gi
-
   volumes:
-    - name: artifacts
-      persistentVolumeClaim:
-        claimName: minio
+    - name: minikube-mount
+      hostPath:
+        path: /nevermined-artifacts
+        type: Directory
 
 status: {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {

--- a/src/compute/compute.service.ts
+++ b/src/compute/compute.service.ts
@@ -100,20 +100,16 @@ export class ComputeService {
   }
 
   private readWorkflowTemplate(gethLocal: boolean): any {
-
-    const workflowFile = gethLocal?'nvm-compute-template-geth-localnet.yaml':'nvm-compute-template.yaml'
-    const templatePath = path.join(
-      __dirname,
-      '/',
-      `../../argo-workflows-templates/${workflowFile}`,
-    )
+    const workflowFile = gethLocal
+      ? 'nvm-compute-template-geth-localnet.yaml'
+      : 'nvm-compute-template.yaml'
+    const templatePath = path.join(__dirname, '/', `../../argo-workflows-templates/${workflowFile}`)
     const templateContent = readFileSync(templatePath, 'utf8')
 
     return yaml.load(templateContent)
   }
 
   async createArgoWorkflow(initData: ExecuteWorkflowDto, agreementId: string): Promise<any> {
-
     const gethLocal = (await this.getNetworkName()) === 'geth-localnet'
 
     const workflow = this.readWorkflowTemplate(gethLocal)
@@ -123,7 +119,11 @@ export class ComputeService {
     Logger.debug(`workflow DDO ${initData.workflowDid} resolved`)
 
     workflow.metadata.namespace = this.configService.computeConfig().argo_namespace
-    workflow.spec.arguments.parameters = await this.createArguments(ddo, initData.consumer, gethLocal)
+    workflow.spec.arguments.parameters = await this.createArguments(
+      ddo,
+      initData.consumer,
+      gethLocal,
+    )
     workflow.spec.workflowMetadata.labels.serviceAgreement = agreementId
 
     workflow.spec.entrypoint = 'compute-workflow'
@@ -143,7 +143,7 @@ export class ComputeService {
   private async createArguments(
     workflowDdo: DDO,
     consumerAddress: string,
-    gethLocal: boolean
+    gethLocal: boolean,
   ): Promise<{ name: string; value: string }[]> {
     const metadata = workflowDdo.findServiceByType('metadata')
     const workflow = metadata.attributes.main.workflow


### PR DESCRIPTION
## Description

uses different templates to post compute workflows to argo-workflows depending on the enviroment. for geth-localnet we use a specific template to map the artifacts to a local folder through minikube