### PR TITLE
remove argo label

### DIFF
--- a/argo-workflows-templates/nvm-compute-template-geth-localnet.yaml
+++ b/argo-workflows-templates/nvm-compute-template-geth-localnet.yaml
@@ -8,8 +8,6 @@ spec:
   entrypoint:
   workflowMetadata:
     labels:
-      # to be set by the compute api
-      serviceAgreementId:
   arguments:
     parameters:
       - name: volume

--- a/argo-workflows-templates/nvm-compute-template.yaml
+++ b/argo-workflows-templates/nvm-compute-template.yaml
@@ -8,8 +8,6 @@ spec:
   entrypoint:
   workflowMetadata:
     labels:
-      # to be set by the compute api
-      serviceAgreementId:
   arguments:
     parameters:
       - name: volume

--- a/src/compute/compute.controller.ts
+++ b/src/compute/compute.controller.ts
@@ -165,7 +165,7 @@ export class ComputeController {
     try {
       Logger.debug(`Executing compute for agreement id ${agreementId}`)
 
-      const argoWorkflow = await this.computeService.createArgoWorkflow(initData, agreementId)
+      const argoWorkflow = await this.computeService.createArgoWorkflow(initData)
       const response = await this.argoWorkflowApi.workflowServiceCreateWorkflow(
         { serverDryRun: false, namespace: this.argoNamespace, workflow: argoWorkflow },
         this.argoNamespace,

--- a/src/compute/compute.service.spec.ts
+++ b/src/compute/compute.service.spec.ts
@@ -216,12 +216,11 @@ describe('ComputeService Testing', () => {
       consumer: '0xaaabbbcc',
     }
 
-    const workflow = await computeService.createArgoWorkflow(initData, 'XXXX')
+    const workflow = await computeService.createArgoWorkflow(initData)
     expect(workflow).toBeDefined()
     expect(workflow.kind).toBe('Workflow')
     expect(workflow.spec).toBeDefined()
     expect(workflow.spec.entrypoint).toBe('compute-workflow')
-    expect(workflow.spec.workflowMetadata.labels.serviceAgreement).toBe('XXXX')
     expect(workflow.spec.templates).toBeDefined()
     expect(workflow.spec.templates.length).toBe(4)
   })

--- a/src/compute/compute.service.ts
+++ b/src/compute/compute.service.ts
@@ -109,7 +109,7 @@ export class ComputeService {
     return yaml.load(templateContent)
   }
 
-  async createArgoWorkflow(initData: ExecuteWorkflowDto, agreementId: string): Promise<any> {
+  async createArgoWorkflow(initData: ExecuteWorkflowDto): Promise<any> {
     const gethLocal = (await this.getNetworkName()) === 'geth-localnet'
     const workflow = this.readWorkflowTemplate(gethLocal)
 

--- a/src/compute/compute.service.ts
+++ b/src/compute/compute.service.ts
@@ -111,7 +111,6 @@ export class ComputeService {
 
   async createArgoWorkflow(initData: ExecuteWorkflowDto, agreementId: string): Promise<any> {
     const gethLocal = (await this.getNetworkName()) === 'geth-localnet'
-
     const workflow = this.readWorkflowTemplate(gethLocal)
 
     Logger.debug(`Resolving workflow DDO ${initData.workflowDid}`)
@@ -120,8 +119,6 @@ export class ComputeService {
 
     workflow.metadata.namespace = this.configService.computeConfig().argo_namespace
     workflow.spec.arguments.parameters = await this.createArguments(ddo, initData.consumer)
-    workflow.spec.workflowMetadata.labels.serviceAgreement = agreementId
-
     workflow.spec.entrypoint = 'compute-workflow'
 
     Logger.debug(


### PR DESCRIPTION
removes service agreement label from argo workflow yaml. It's not used and it's causing problems because its length