### PR TITLE
fix: missing await when decrypting urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {

--- a/src/shared/nevermined/nvm.service.ts
+++ b/src/shared/nevermined/nvm.service.ts
@@ -6,6 +6,7 @@ import {
   DDO,
   MetaDataMain,
   Nevermined,
+  MetaDataExternalResource,
 } from '@nevermined-io/sdk'
 import {
   BadRequestException,
@@ -87,7 +88,10 @@ export class NeverminedService {
     const name = file_attributes.name
     const auth_method = asset.findServiceByType('authorization').service || 'RSAES-OAEP'
     if (auth_method === 'RSAES-OAEP') {
-      const filelist = this.decrypt(service.attributes.encryptedFiles, 'PSK-RSA')
+      const filelist: MetaDataExternalResource = await this.decrypt(
+        service.attributes.encryptedFiles,
+        'PSK-RSA',
+      )
 
       // download url or what?
       const url: string = filelist[index].url


### PR DESCRIPTION
## Description

- Fix a bug introduced by a missing `await` when refactoring the decryption method
- bumped version to `1.1.1`

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
