### PR TITLE
fix: getDuration should also work with nft-sales-proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {

--- a/src/access/access.controller.ts
+++ b/src/access/access.controller.ts
@@ -34,7 +34,13 @@ import { Logger } from '../shared/logger/logger.service'
 import { TransferDto } from './dto/transfer'
 import { UploadDto } from './dto/upload'
 import { UploadResult } from './dto/upload-result'
-import { generateId, ValidationParams, BigNumber, AgreementData } from '@nevermined-io/sdk'
+import {
+  generateId,
+  ValidationParams,
+  BigNumber,
+  AgreementData,
+  ServiceType,
+} from '@nevermined-io/sdk'
 import { aes_encryption_256 } from '@nevermined-io/sdk-dtp'
 
 export enum UploadBackends {
@@ -145,7 +151,7 @@ export class AccessController {
     }
 
     const subscriptionDDO = await this.nvmService.nevermined.assets.resolve(agreement.did)
-    const duration = await this.nvmService.getDuration(subscriptionDDO)
+    const duration = await this.nvmService.getDuration(subscriptionDDO, template as ServiceType)
 
     let expiration = 0
     if (duration > 0) {

--- a/src/shared/nevermined/nvm.service.ts
+++ b/src/shared/nevermined/nvm.service.ts
@@ -12,6 +12,7 @@ import {
   Service,
   DDOServiceNotFoundError,
   findServiceConditionByName,
+  ServiceType,
 } from '@nevermined-io/sdk'
 import {
   BadRequestException,
@@ -411,19 +412,23 @@ export class NeverminedService {
    * Get the duration of the subscription in number of blocks
    *
    * @param subscriptionDDO - The DDO of the subscription
+   * @param serviceType - The service to fetch the duration from. Usually 'nft-sales' and 'nft-sales-proof'
    *
    * @throws {@link BadRequestException}
    * @returns {@link Promise<number>} The duration in number of blocks
    */
-  public async getDuration(subscriptionDDO: DDO): Promise<number> {
+  public async getDuration(
+    subscriptionDDO: DDO,
+    serviceType: ServiceType = 'nft-sales',
+  ): Promise<number> {
     // get the nft-sales service
-    let nftSalesService: Service<'nft-sales'>
+    let nftSalesService: Service
     try {
-      nftSalesService = subscriptionDDO.findServiceByType('nft-sales')
+      nftSalesService = subscriptionDDO.findServiceByType(serviceType)
     } catch (e) {
       if (e instanceof DDOServiceNotFoundError) {
         throw new BadRequestException(
-          `${subscriptionDDO.id} does not contain an 'nft-sales' service`,
+          `${subscriptionDDO.id} does not contain an '${serviceType}' service`,
         )
       } else {
         throw e


### PR DESCRIPTION


## Description

- fix an issue where getDuration was not working with the `nft-sales-proof` service
- bumped version to 1.2.3

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
