### PR TITLE
feat: subscription accessToken now returns the owner of the webservice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {

--- a/src/subscriptions/subscriptions.controller.ts
+++ b/src/subscriptions/subscriptions.controller.ts
@@ -33,7 +33,7 @@ export class SubscriptionsController {
   @ApiBearerAuth('Authorization')
   async getAccessToken(@Req() req, @Param('did') did: string): Promise<SubscriptionTokenDto> {
     // get subscription data
-    const { contractAddress, numberNfts, endpoints, headers } =
+    const { contractAddress, numberNfts, endpoints, headers, owner } =
       await this.subscriptionService.validateDid(did)
 
     // validate that the subscription is valid
@@ -62,9 +62,10 @@ export class SubscriptionsController {
     // get access token
     const accessToken = await this.subscriptionService.generateToken(
       did,
-      req.user.iss,
+      req.user.address,
       endpoints,
       expiryTime,
+      owner,
       headers,
     )
 

--- a/src/subscriptions/subscriptions.service.ts
+++ b/src/subscriptions/subscriptions.service.ts
@@ -17,6 +17,7 @@ export interface SubscriptionData {
   contractAddress: string
   endpoints: string[]
   headers: { [key: string]: string }[]
+  owner: string
 }
 
 @Injectable()
@@ -122,11 +123,15 @@ export class SubscriptionsService {
       'PSK-RSA',
     )
 
+    // get the owner of the DID
+    const [{ owner }] = ddo.publicKey
+
     return {
       numberNfts,
       contractAddress,
       endpoints,
       headers,
+      owner,
     }
   }
 
@@ -174,6 +179,7 @@ export class SubscriptionsService {
     userAddress: string,
     endpoints: any,
     expiryTime: number | string,
+    owner: string,
     headers?: any,
   ): Promise<string> {
     return await new jose.EncryptJWT({
@@ -181,6 +187,7 @@ export class SubscriptionsService {
       userId: userAddress,
       endpoints,
       headers,
+      owner,
     })
       .setProtectedHeader({ alg: 'dir', enc: 'A128CBC-HS256' })
       .setIssuedAt()


### PR DESCRIPTION


## Description

- return the owner of the webservice ddo in the jwt token
- fixed a bug where the subscriber address was not being sent in the token

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/one/issues/352

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
