### PR TITLE
Feat/subscription token owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "1.2.17",
+  "version": "1.3.1",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {


### PR DESCRIPTION
## Description

- allow the owner of a webservice to get the subscription jwt token without having to be an nftholder
- added tests
- bumped version to 1.2.17

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/one/issues/526

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
