### PR TITLE
Integration with the NVM Backend to record asset txs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -34,3 +34,8 @@ NEVERMINED_PROXY_URI=https://proxy.nevermined.one
 
 # for testing porposes
 SEED_WORDS="taxi music thumb unique chat sand crew more leg another off lamp"
+
+
+NVM_BACKEND_URL="http://localhost:3000"
+NVM_BACKEND_AUTH="eyJhbG.dsadsads.dsdsadsa"
+TRACK_BACKEND_TXS="true"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The Nevermined Node reads the following environment variables allowing the confi
 | **NETWORK_AVERAGE_BLOCK_TIME**       | The average block time in milliseconds for the connected network. Used to calculate the expiry time of the subscriptions token. Defaults 2100 milliseconds       | `2100`                                                                    |
 | **NEVERMINED_SDK_LOG_LEVEL**         | The log level of the nevermined sdk (0: Error, 1: Warn, 2: Log, 3: Verbose). Defaults to `0`                                                                     | `0`                                                                       |
 | **ZERODEV_PROJECT_ID**               | Optional [zerodev](https://zerodev.app/) _project id_ to allow the node to use a smart contract wallet                                                           | `4b1b45db-d7hg-864c-357a-8e9581b86358`                                    |
+| **NVM_BACKEND_URL**                  | Optional url of the Nevermined Backend. If given the backend can be used to store asset transactions                                                             |                                                                           |
+| **NVM_BACKEND_AUTH**                 | JWT token to authenticate in the Nevermined Backend                                                                                                              |                                                                           |
+| **TRACK_BACKEND_TXS**                | If `true` and the Nevermined Backend is configured via the `NVM_BACKEND_URL` env variable it will track the mint asset transactions                              |                                                                           |
 
 ## Install and run:
 

--- a/config/from-env.js
+++ b/config/from-env.js
@@ -41,6 +41,10 @@ const keys = [
 
   'ZERODEV_PROJECT_ID',
 
+  'NVM_BACKEND_URL',
+  'NVM_BACKEND_AUTH',
+  'TRACK_BACKEND_TXS',
+
   // for testing
   'SEED_WORDS',
 ]

--- a/config/nevermined.js
+++ b/config/nevermined.js
@@ -1,5 +1,6 @@
 const LogLevel = require('@nevermined-io/sdk').LogLevel
 const ethers = require('ethers').ethers
+const { NeverminedOptions } = require('@nevermined-io/sdk')
 const fs = require('fs')
 
 const configBase = {

--- a/integration/access.integration.spec.ts
+++ b/integration/access.integration.spec.ts
@@ -4,13 +4,13 @@ import { Test } from '@nestjs/testing'
 import { JwtAuthGuard } from '../src/common/guards/auth/jwt-auth.guard'
 import { AccessController } from '../src/access/access.controller'
 import { NeverminedModule } from '../src/shared/nevermined/nvm.module'
+import { BackendModule } from '../src/shared/backend/backend.module'
 import request from 'supertest'
 import { PassportModule } from '@nestjs/passport'
 import { JwtModule } from '@nestjs/jwt'
 import { AuthService } from '../src/auth/auth.service.mock'
 import { JwtStrategy } from '../src/common/strategies/jwt.strategy'
 import { ConfigModule } from '../src/shared/config/config.module'
-import { BackendModule } from 'src/shared/backend/backend.module'
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
 

--- a/integration/access.integration.spec.ts
+++ b/integration/access.integration.spec.ts
@@ -10,6 +10,7 @@ import { JwtModule } from '@nestjs/jwt'
 import { AuthService } from '../src/auth/auth.service.mock'
 import { JwtStrategy } from '../src/common/strategies/jwt.strategy'
 import { ConfigModule } from '../src/shared/config/config.module'
+import { BackendModule } from 'src/shared/backend/backend.module'
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
 
@@ -20,6 +21,7 @@ describe('Info', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         NeverminedModule,
+        BackendModule,
         ConfigModule,
         PassportModule,
         JwtModule.register({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Nevermined Node",
   "main": "main.ts",
   "scripts": {
@@ -36,7 +36,7 @@
     "@nestjs/typeorm": "^10.0.0",
     "@nevermined-io/argo-workflows-api": "^0.1.3",
     "@nevermined-io/passport-nevermined": "^0.3.0",
-    "@nevermined-io/sdk": "^2.0.7",
+    "@nevermined-io/sdk": "^2.0.8",
     "@nevermined-io/sdk-dtp": "^0.7.0-rc5",
     "@sideway/address": "^5.0.0",
     "@sideway/formula": "^3.0.1",

--- a/src/access/access.module.ts
+++ b/src/access/access.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common'
 import { NeverminedModule } from '../shared/nevermined/nvm.module'
+import { BackendModule } from '../shared/backend/backend.module'
 import { AccessController } from './access.controller'
 
 @Module({
   providers: [],
-  imports: [NeverminedModule],
+  imports: [NeverminedModule, BackendModule],
   controllers: [AccessController],
   exports: [],
 })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module'
 import { EncryptModule } from './encrypt/encrypt.module'
 import { AccessModule } from './access/access.module'
 import { NeverminedModule } from './shared/nevermined/nvm.module'
+import { BackendModule } from './shared/backend/backend.module'
 import { ComputeModule } from './compute/compute.module'
 import { SubscriptionsModule } from './subscriptions/subscriptions.module'
 
@@ -22,6 +23,7 @@ import { SubscriptionsModule } from './subscriptions/subscriptions.module'
     NeverminedModule,
     ComputeModule,
     SubscriptionsModule,
+    BackendModule,
   ],
 })
 export class ApplicationModule {

--- a/src/shared/backend/backend.module.ts
+++ b/src/shared/backend/backend.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { HttpModule } from '@nestjs/axios'
+import { BackendService } from './backend.service'
+import { ConfigModule } from '../config/config.module'
+
+@Module({
+  imports: [ConfigModule, HttpModule],
+  providers: [BackendService],
+  exports: [BackendService],
+})
+export class BackendModule {}

--- a/src/shared/backend/backend.service.ts
+++ b/src/shared/backend/backend.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InternalServerErrorException } from '@nestjs/common'
+import { ConfigService } from '../config/config.service'
+import { firstValueFrom } from 'rxjs'
+import { HttpModuleOptions, HttpService } from '@nestjs/axios'
+
+export interface AssetTransaction {
+  assetDid: string
+  assetOwner: string
+  assetConsumer: string
+  txType: string
+  price: string
+  currency: string
+  paymentType: string
+  txHash?: string
+  metadata?: string
+}
+
+@Injectable()
+export class BackendService {
+  isNVMBackendEnabled = false
+  trackBackendTxs: boolean
+  backendUrl: string
+  backendAuth: string
+
+  constructor(private config: ConfigService, private readonly httpService: HttpService) {}
+
+  async onModuleInit() {
+    Logger.debug(`Starting BackendService`)
+
+    try {
+      this.trackBackendTxs = this.config.backendConfig().trackBackendTxs
+      this.backendUrl = this.config.backendConfig().backendUrl
+      this.backendAuth = this.config.backendConfig().backendAuth
+      this.isNVMBackendEnabled = this.config.backendConfig().isNVMBackendEnabled
+
+      Logger.log(`Backend Config: `)
+      Logger.log(`Is Backend Enabled: ${this.isNVMBackendEnabled}`)
+      Logger.log(this.trackBackendTxs)
+      Logger.log(this.backendUrl)
+      Logger.log(this.backendAuth)
+    } catch (e) {
+      Logger.warn(e)
+    }
+  }
+
+  public isBackendEnabled(): boolean {
+    return this.isNVMBackendEnabled
+  }
+
+  public async recordAssetTransaction(assetTx: AssetTransaction): Promise<boolean> {
+    if (!this.isNVMBackendEnabled || !this.trackBackendTxs) {
+      Logger.warn('Backend transactions recording is disabled by config')
+      return false
+    }
+
+    const requestConfig: HttpModuleOptions = {
+      url: `${this.backendUrl}/api/v1/transactions/asset`,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.backendAuth}`,
+        'Content-Type': 'application/json',
+      },
+      data: assetTx,
+    }
+
+    const response = await firstValueFrom(this.httpService.request(requestConfig))
+    const obj = response.data
+
+    if (obj.error) {
+      Logger.error('Backend returned an error message:', obj.error)
+      throw new InternalServerErrorException(obj.error)
+    }
+
+    return true
+  }
+}

--- a/src/shared/config/config.service.ts
+++ b/src/shared/config/config.service.ts
@@ -37,6 +37,13 @@ export interface SubscriptionsConfig {
   averageBlockTime: number
 }
 
+export interface BackendConfig {
+  isNVMBackendEnabled: boolean
+  trackBackendTxs: boolean
+  backendUrl: string
+  backendAuth: string
+}
+
 const configProfile = require('../../../config')
 
 const DOTENV_SCHEMA = Joi.object({
@@ -88,6 +95,9 @@ const DOTENV_SCHEMA = Joi.object({
   COMPUTE_PROVIDER_PASSWORD: Joi.string(),
   NEVERMINED_PROXY_URI: Joi.string(),
   ZERODEV_PROJECT_ID: Joi.string(),
+  NVM_BACKEND_URL: Joi.string(),
+  NVM_BACKEND_AUTH: Joi.string(),
+  TRACK_BACKEND_TXS: Joi.string(),
 })
 
 type DotenvSchemaKeys =
@@ -127,12 +137,16 @@ type DotenvSchemaKeys =
   | 'SUBSCRIPTION_DEFAULT_EXPIRY_TIME'
   | 'NETWORK_AVERAGE_BLOCK_TIME'
   | 'ZERODEV_PROJECT_ID'
+  | 'NVM_BACKEND_URL'
+  | 'NVM_BACKEND_AUTH'
+  | 'TRACK_BACKEND_TXS'
 
 export class ConfigService {
   private readonly envConfig: EnvConfig
   private readonly crypto: CryptoConfig
   private readonly compute: ComputeConfig
   private readonly subscriptions: SubscriptionsConfig
+  private readonly backend: BackendConfig
 
   constructor() {
     this.envConfig = this.validateInput(configProfile)
@@ -165,6 +179,12 @@ export class ConfigService {
       defaultExpiryTime: this.get<string>('SUBSCRIPTION_DEFAULT_EXPIRY_TIME'),
       averageBlockTime: this.get<number>('NETWORK_AVERAGE_BLOCK_TIME'),
     }
+    this.backend = {
+      isNVMBackendEnabled: this.get<string>('NVM_BACKEND_URL') !== '',
+      trackBackendTxs: this.get<string>('TRACK_BACKEND_TXS') === 'true',
+      backendUrl: this.get<string>('NVM_BACKEND_URL'),
+      backendAuth: this.get<string>('NVM_BACKEND_AUTH'),
+    }
   }
 
   get<T>(path: DotenvSchemaKeys): T | undefined {
@@ -185,6 +205,10 @@ export class ConfigService {
 
   subscriptionsConfig(): SubscriptionsConfig {
     return this.subscriptions
+  }
+
+  backendConfig(): BackendConfig {
+    return this.backend
   }
 
   getProviderBabyjub() {

--- a/src/shared/nevermined/nvm.service.ts
+++ b/src/shared/nevermined/nvm.service.ts
@@ -13,6 +13,8 @@ import {
   ServiceType,
   generateInstantiableConfigFromConfig,
   convertEthersV6SignerToAccountSigner,
+  ServiceCommon,
+  DDOError,
 } from '@nevermined-io/sdk'
 import {
   BadRequestException,
@@ -487,6 +489,13 @@ export class NeverminedService {
     const duration = DDO.getParameterFromCondition(nftSalesService, 'transferNFT', '_duration')
     // non-subscription nfts have no expiration
     return Number(duration) || 0
+  }
+
+  public getAssetPrice(service: ServiceCommon): bigint {
+    const assetPrice = DDO.getAssetPriceFromService(service)
+
+    if (assetPrice) return assetPrice.getTotalPrice()
+    throw new DDOError(`No price found for asset ${service.index}`)
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
     snarkjs "^0.4.26"
     web3-utils "^1.7.4"
 
-"@nevermined-io/sdk@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@nevermined-io/sdk/-/sdk-2.0.7.tgz#b08129f22f0f0982d7b7f3930d7c423af2cfefbf"
-  integrity sha512-1k5eSK2kWDDb+6jjcK9Z1ayQCab7HRdShcYzAWXIj3O2qerM/kBPSbtHvFTYufsUThP+elGC/LfuTvSPyzClEA==
+"@nevermined-io/sdk@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@nevermined-io/sdk/-/sdk-2.0.8.tgz#d28df59b690b2f48a3cfc1db3090ede5bcd7356a"
+  integrity sha512-T+HVgmpud9fjvdWVlEZIRXDrLlbjpjLm49Mi25uNqy6nMHN5F9D8H91+7xVW6EcVeWZKj/nT22ziFdFHBPMQ9w==
   dependencies:
     "@alchemy/aa-core" "0.1.1"
     "@apollo/client" "^3.7.16"


### PR DESCRIPTION
## Description

When the proper NVM Backend config is given it will record the mint asset txs. This will help to consolidate the on-chain/off-chain txs.

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/internal/issues/585

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
